### PR TITLE
Modified Signature checks

### DIFF
--- a/src/SecurityTxtToolkit.psm1
+++ b/src/SecurityTxtToolkit.psm1
@@ -374,7 +374,7 @@ Function Test-SecurityTxtFile {
 
 			$SigningProcess = @{
 				'FilePath' = $GnuPGApp.Source
-				'ArgumentList' = '--verify'
+				'ArgumentList' = @('--verify', '--status-fd=2') # note =2 will per default put the extra info into STDERR
 				'LoadUserProfile' = $true	# to use the user's $env:GNUPGHOME
 				'RedirectStandardInput'  = $VerifyStdinFile
 				'RedirectStandardError'  = $VerifyStderrFile
@@ -386,18 +386,23 @@ Function Test-SecurityTxtFile {
 			# On my system, `gpg --verify` emits to stderr.  Not sure why.
 			# Just in case it emits to stdout on your system, we'll pull from
 			# the stdout file in case stderr is blank.
-			$VerifyResults = Get-Content $VerifyStderrFile
+			$VerifyResults = Get-Content $VerifyStderrFile -Raw
 			Write-Debug "Error stream from gpg:  $VerifyResults"
 			If ($null -eq $VerifyResults) {
-				$VerifyResults = Get-Content $VerifyStdoutFile
+				$VerifyResults = Get-Content $VerifyStdoutFile -Raw
 				Write-Debug "Error stream null.  Switching to output stream:  $VerifyResults"
 			}
 
-			$Return.IsSigned = $null -ne (Select-String -InputObject $VerifyResults -Pattern 'signature from')
+			$Return.IsSigned = $VerifyResults -match '\[GNUPG\:\] NEWSIG'
 			If ($Return.IsSigned) {
-				$Return.IsSignedBy = ($VerifyResults -Replace 'gpg:\s*','')
+				# The pattern constructs itself as follows:
+				# '\[GNUPG\:\] ' The GNUPG status-fd preamble
+				# '(?:NEW|GOOD)SIG' Either gnupg has a matching key in the keyring then GOODSIG else NEWSIG
+				# '(.*)' Signer
+				$Pattern = '\[GNUPG\:\] (?:NEW|GOOD)SIG (.*)'
+				$Return.IsSignedBy =  (Select-String -InputObject $VerifyResults -Pattern $Pattern).Matches.Groups[1].Value
 			}
-			$Return.HasGoodSignature = $null -ne (Select-String -InputObject $VerifyResults -Pattern 'good signature from')
+			$Return.HasGoodSignature = $VerifyResults -match '\[GNUPG\:\] VALIDSIG'
 		}
 		Finally {
 			Remove-Item -Path $VerifyStdinFile  -Force -ErrorAction Ignore


### PR DESCRIPTION
This adds signature checks via the use of `status-fd`

Notes:
* This will probably obsololte the checking of different output stream since status-fd will specify which one to check
* The use of `[...].Matches.Groups[1].Value` shouldn't cause an error. (Or at least it didn't in my testing) it would be possible to rewrite this to handle strange edge case which could cause a null index error

WARNING:
this may break Signature Checking for keys which aren't already within the current keystore.

The `correct` way to handle that should be to import said key before checking the signature.

This could maybe be handled within this module but that would _probably_ fall out of the scope of this PR.

fixes #3 